### PR TITLE
Global Sharing Pop-Up Improvements and Detail View

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -2,15 +2,15 @@
 from flask import Flask
 from flask_sqlalchemy import SQLAlchemy
 from flask_migrate import Migrate
-from flask_login import LoginManager
+from flask_login import LoginManager, current_user
 from config import Config
 
 # instantiate the extensions
 db = SQLAlchemy()
 migrate = Migrate()
 login_manager = LoginManager()
-login_manager.login_view = 'auth.login' # 'auth' is the blueprint name, 'login' is the function name
-login_manager.login_message = 'Please log in to access this page.' 
+login_manager.login_view = 'auth.login'
+login_manager.login_message = 'Please log in to access this page.'
 login_manager.login_message_category = 'info'
 
 def create_app(config_class=Config):
@@ -21,12 +21,22 @@ def create_app(config_class=Config):
     migrate.init_app(app, db)
     login_manager.init_app(app)
 
+    # Unread Share Count Context Processor
+    @app.context_processor
+    def inject_unread_share_count():
+        from app.models import ShareRecord
+        if current_user.is_authenticated:
+            cnt = ShareRecord.query \
+                .filter_by(receiver_id=current_user.id, is_read=False) \
+                .count()
+        else:
+            cnt = 0
+        return {'unread_share_count': cnt}
+
     from app.routes.auth import bp as auth_bp
     app.register_blueprint(auth_bp, url_prefix='/auth')
 
     from app.routes.main import bp as main_bp 
     app.register_blueprint(main_bp)
-    # return the app instance
-    return app
 
-from app.models import User, FoodItem, FoodLog
+    return app

--- a/app/models.py
+++ b/app/models.py
@@ -75,7 +75,7 @@ class FoodItem(db.Model):
     logs = db.relationship('FoodLog', backref='food_details', lazy='dynamic')
 
     # Sets the user who created the food item.
-    user_id = db.Column(db.Integer, db.ForeignKey('user.id', name='fk_fooditem_user_id'), nullable=True, index=True)
+    user_id = db.Column(db.Integer, db.ForeignKey('user.id', name='fk_fooditem_user_id'), nullable=False, index=True)
 
     # String representation for debugging.
     def __repr__(self):

--- a/app/routes/main.py
+++ b/app/routes/main.py
@@ -608,45 +608,45 @@ def time_ago(dt):
     else:
         return f"{int(seconds // 86400)} days ago"
     
-@bp.route('/share', methods=['GET', 'POST'])
+@bp.route('/share', methods=['GET','POST'])
 @login_required
 def share():
     form = ShareForm()
-    friends = []
-    # ---------------- GET 搜索处理 ----------------
-    #匹配所有用户（排除自己）
     search_term = request.args.get('search','').strip()
+    friends = []
+
     if search_term:
         friends = User.query \
-        .filter(User.id != current_user.id) \
-        .filter(
-            or_(
+            .filter(User.id != current_user.id) \
+            .filter(or_(
                 User.first_name.ilike(f"%{search_term}%"),
                 User.last_name.ilike(f"%{search_term}%"),
                 User.email.ilike(f"%{search_term}%")
-            )
-        ) \
-        .limit(10) \
-        .all()  # TODO：暂时只取前 10 个匹配；考虑分页或滚轮
-    else:
-        # 默认不展示，避免数据量大
-        friends = []
+            )).limit(10).all()
 
+    # JSON 请求
+    if request.method == 'GET' and request.headers.get('Accept') == 'application/json':
+        return jsonify([
+            {'id': u.id,
+             'first_name': u.first_name,
+             'last_name': u.last_name,
+             'email': u.email}
+            for u in friends
+        ])
 
-    # ---------------- POST 提交分享 ----------------
+    # POST 提交分享
     if request.method == 'POST':
         content_type = request.form.get('content_type')
-        date_range = request.form.get('date_range')
-        selected_friend_id = request.form.get('selected_friend_id')
+        date_range   = request.form.get('date_range')
+        selected_id  = request.form.get('selected_friend_id')
 
-        if not selected_friend_id:
+        if not selected_id:
             flash("Please select a friend to share with.")
-            return render_template('share.html',form=form, friends=friends)
+            return render_template('share.html', form=form, friends=friends)
 
-        # 写入 ShareRecord 表
         new_share = ShareRecord(
             sender_id=current_user.id,
-            receiver_id=int(selected_friend_id),
+            receiver_id=int(selected_id),
             content_type=content_type,
             date_range=date_range,
             timestamp=datetime.now(timezone.utc)
@@ -656,8 +656,8 @@ def share():
         flash("Content shared successfully.")
         return redirect(url_for('main.dashboard'))
 
-    return render_template('share.html',form=form , friends=friends)
-
+    # 普通 GET 渲染页面 —— 注意这里 friends 要用上面查询出来的
+    return render_template('share.html', form=form, friends=friends)
 
 @bp.route('/sharin_list')
 def sharing_list():

--- a/app/static/share_modal.js
+++ b/app/static/share_modal.js
@@ -1,0 +1,78 @@
+// static/share_modal.js
+;(function(){
+  // 1. 找到 Modal 元素并实例化
+  const shareModalEl = document.getElementById('shareModal');
+  if (!shareModalEl) return;
+  const shareModal = new bootstrap.Modal(shareModalEl);
+
+  // 2. 触发按钮：侧边栏那个 link
+  const trigger = document.querySelector('a[data-bs-target="#shareModal"]');
+  if (trigger) {
+    trigger.addEventListener('click', function(e){
+      e.preventDefault();
+      // 每次打开前清空搜索框和结果
+      const input = document.getElementById('friendSearchInput');
+      const list  = document.getElementById('friendListContainerGlobal');
+      if (input) input.value = '';
+      if (list)  list.innerHTML = '';
+      shareModal.show();
+    });
+  }
+
+  // 3. 搜索相关元素
+  const input         = document.getElementById('friendSearchInput');
+  const btn           = document.getElementById('friendSearchBtn');
+  const listContainer = document.getElementById('friendListContainerGlobal');
+  // 这里的 URL 要跟你的 Flask 路由保持一致
+  const baseUrl       = window.SHARE_MODAL_BASE_URL;
+
+  if (!input || !btn || !listContainer || !baseUrl) {
+    console.error('Share modal: missing elements or baseUrl');
+    return;
+  }
+
+  // 4. 渲染函数
+  function renderFriends(users) {
+    if (!users.length) {
+      listContainer.innerHTML = `<p class="text-muted">
+        No matching friends for “${input.value.trim()}”
+      </p>`;
+      return;
+    }
+    listContainer.innerHTML = users.map(u => `
+      <label class="list-group-item">
+        <input class="form-check-input me-2" type="radio"
+               name="selected_friend_id"
+               value="${u.id}" required>
+        ${u.first_name} ${u.last_name} (${u.email})
+      </label>
+    `).join('');
+  }
+
+  // 5. 点击搜索
+  btn.addEventListener('click', async function(){
+    const q = input.value.trim();
+    if (!q) {
+      listContainer.innerHTML = '';
+      return;
+    }
+    try {
+      const resp = await fetch(`${baseUrl}?search=${encodeURIComponent(q)}`, {
+        headers: { 'Accept': 'application/json' }
+      });
+      if (!resp.ok) throw new Error(resp.status);
+      const users = await resp.json();
+      renderFriends(users);
+    } catch (err) {
+      console.error('Share modal search error', err);
+    }
+  });
+
+  // 6. 回车触发搜索
+  input.addEventListener('keydown', function(e){
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      btn.click();
+    }
+  });
+})();

--- a/app/templates/home_base.html
+++ b/app/templates/home_base.html
@@ -67,12 +67,12 @@
                         </a>
                     </div>
                     <div class="nav-icon-row">
-                        <a href="{{ url_for('main.share') }}"
-                            class="nav-icon {% if request.endpoint == 'main.friends' %}active{% endif %}">
+                        <a href="#" id="openShareBtn" class="nav-icon" data-bs-toggle="modal"
+                            data-bs-target="#shareModal">
                             <i class="fa-solid fa-users"></i>
                         </a>
                         <a href="{{ url_for('main.sharing_list') }}"
-                            class="nav-icon {% if request.endpoint == 'main.sharing_list' %}active{% endif %}">
+                            class="nav-icon {% if request.endpoint == 'main.sharin_list' %}active{% endif %}">
                             <i class="fa-solid fa-list"></i>
                         </a>
                     </div>
@@ -89,6 +89,78 @@
             <div class="main-content">
                 {% block content %}{% endblock %}
             </div>
+            <!-- —— 全局 Share Modal —— -->
+
+            <!-- Share Modal -->
+            <div class="modal fade" id="shareModal" tabindex="-1" aria-hidden="true">
+                <div class="modal-dialog modal-dialog-centered modal-lg">
+                    <div class="modal-content">
+                        <div class="modal-header">
+                            <h5 id="shareModalLabel" class="modal-title">Share to Friends</h5>
+                            <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+                        </div>
+                        <div class="modal-body">
+                            <form id="shareFormGlobal" method="POST" action="{{ url_for('main.share') }}">
+                                {{ form.hidden_tag() }}
+
+                                <!-- 1. 图表类型（内容类型） -->
+                                <fieldset class="mb-3">
+                                    <legend class="form-label">Select content to share</legend>
+                                    <div class="form-check">
+                                        <input class="form-check-input" type="radio" name="content_type" value="ranking"
+                                            id="ctRanking" checked>
+                                        <label class="form-check-label" for="ctRanking">My Current Ranking</label>
+                                    </div>
+                                    <div class="form-check">
+                                        <input class="form-check-input" type="radio" name="content_type" value="calorie"
+                                            id="ctCalorie">
+                                        <label class="form-check-label" for="ctCalorie">My Calorie Intake</label>
+                                    </div>
+                                </fieldset>
+
+                                <!-- 2. 周期选择 -->
+                                <fieldset class="mb-3">
+                                    <legend class="form-label">Select Data Range</legend>
+                                    <div class="form-check form-check-inline">
+                                        <input class="form-check-input" type="radio" name="date_range" id="drDaily"
+                                            value="daily">
+                                        <label class="form-check-label" for="drDaily">Daily</label>
+                                    </div>
+                                    <div class="form-check form-check-inline">
+                                        <input class="form-check-input" type="radio" name="date_range" id="drWeekly"
+                                            value="weekly" checked>
+                                        <label class="form-check-label" for="drWeekly">Weekly</label>
+                                    </div>
+                                    <div class="form-check form-check-inline">
+                                        <input class="form-check-input" type="radio" name="date_range" id="drMonthly"
+                                            value="monthly">
+                                        <label class="form-check-label" for="drMonthly">Monthly</label>
+                                    </div>
+                                </fieldset>
+
+                                <!-- 3. 好友搜索 -->
+                                <div class="input-group mb-3">
+                                    <input id="friendSearchInput" type="text" class="form-control"
+                                        placeholder="Find your friend">
+                                    <button id="friendSearchBtn" type="button" class="btn btn-outline-secondary">
+                                        <i class="fas fa-search"></i>
+                                    </button>
+                                </div>
+
+                                <!-- 4. 好友列表 -->
+                                <div id="friendListContainerGlobal" class="list-group mb-3">
+                                    <!-- AJAX 渲染结果放这里 -->
+                                </div>
+                            </form>
+                        </div>
+                        <div class="modal-footer">
+                            <button form="shareFormGlobal" type="submit" class="btn btn-primary">Confirm</button>
+                            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
         </div>
     </div>
 
@@ -97,7 +169,17 @@
     <!-- jQuery -->
     <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
     <!-- Custom JS -->
+    <!-- Search friend -->
+    <script>
+        window.SHARE_MODAL_BASE_URL = "{{ url_for('main.share') }}";
+    </script>
+
+    <script src="{{ url_for('static', filename='share_modal.js') }}" defer></script>
+  
     {% block extra_js %}{% endblock %}
+
+
+
     <script defer>
         const messages = {{ get_flashed_messages() | tojson }};
         if (messages.length > 0) {

--- a/app/templates/home_base.html
+++ b/app/templates/home_base.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -12,6 +13,7 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='style_dashboard.css') }}">
     {% block extra_css %}{% endblock %}
 </head>
+
 <body>
     <div class="dashboard-container">
         <!-- Top Navigation Bar -->
@@ -22,8 +24,17 @@
                     <a class="nav-link active" href="{{ url_for('main.dashboard') }}">Home</a>
                 </div>
                 <div class="navbar-nav ms-auto">
-                    <a class="nav-link" href="#"><i class="fa-solid fa-bell"></i></a>
-                    <a class="nav-link" href="{{ url_for('auth.logout') }}"><i class="fa-solid fa-sign-out-alt"></i> Logout</a>
+                    <a class="nav-link position-relative" href="{{ url_for('main.sharing_list') }}">
+                        <i class="fa-solid fa-bell"></i>
+                        {% if unread_share_count %}
+                        <span class="position-absolute top-0 start-100 translate-middle badge rounded-pill bg-danger">
+                            {{ unread_share_count }}
+                            <span class="visually-hidden">unread notifications</span>
+                        </span>
+                        {% endif %}
+                    </a>
+                    <a class="nav-link" href="{{ url_for('auth.logout') }}"><i class="fa-solid fa-sign-out-alt"></i>
+                        Logout</a>
                 </div>
             </div>
         </nav>
@@ -42,27 +53,32 @@
                         <i class="fa-solid fa-bullseye"></i> {{ current_user.target_calories }} kcal
                     </div>
                 </div>
-                
+
                 <!-- Navigation Section -->
                 <div class="navigation-section">
                     <div class="nav-icon-row">
-                        <a href="{{ url_for('main.dashboard') }}" class="nav-icon {% if request.endpoint == 'main.index' %}active{% endif %}">
+                        <a href="{{ url_for('main.dashboard') }}"
+                            class="nav-icon {% if request.endpoint == 'main.index' %}active{% endif %}">
                             <i class="fa-solid fa-house"></i>
                         </a>
-                        <a href="{{ url_for('main.addMeal') }}" class="nav-icon {% if request.endpoint == 'main.addMeal' %}active{% endif %}">
+                        <a href="{{ url_for('main.addMeal') }}"
+                            class="nav-icon {% if request.endpoint == 'main.addMeal' %}active{% endif %}">
                             <i class="fa-solid fa-plus"></i>
                         </a>
                     </div>
                     <div class="nav-icon-row">
-                        <a href="{{ url_for('main.share') }}" class="nav-icon {% if request.endpoint == 'main.friends' %}active{% endif %}">
+                        <a href="{{ url_for('main.share') }}"
+                            class="nav-icon {% if request.endpoint == 'main.friends' %}active{% endif %}">
                             <i class="fa-solid fa-users"></i>
                         </a>
-                        <a href="{{ url_for('main.sharing_list') }}" class="nav-icon {% if request.endpoint == 'main.sharing_list' %}active{% endif %}">
+                        <a href="{{ url_for('main.sharing_list') }}"
+                            class="nav-icon {% if request.endpoint == 'main.sharing_list' %}active{% endif %}">
                             <i class="fa-solid fa-list"></i>
                         </a>
                     </div>
                     <div class="nav-icon-row">
-                        <a href="{{ url_for('main.settings') }}" class="nav-icon {% if request.endpoint == 'main.settings' %}active{% endif %}">
+                        <a href="{{ url_for('main.settings') }}"
+                            class="nav-icon {% if request.endpoint == 'main.settings' %}active{% endif %}">
                             <i class="fa-solid fa-gear"></i>
                         </a>
                     </div>
@@ -83,10 +99,11 @@
     <!-- Custom JS -->
     {% block extra_js %}{% endblock %}
     <script defer>
-        const messages = {{ get_flashed_messages()|tojson }};
+        const messages = {{ get_flashed_messages() | tojson }};
         if (messages.length > 0) {
             alert(messages.join('\n'));
         }
     </script>
 </body>
+
 </html>

--- a/app/templates/share.html
+++ b/app/templates/share.html
@@ -9,7 +9,9 @@
 {% block content %}
 <div class="share-modal">
     <h2 class="share-modal-title">Share to Friends</h2>
-    <form method="POST" action="{{ url_for('main.share') }}">
+    <form id="shareForm" method="POST"
+        action="{{ url_for('main.share') }}{% if request.args.get('search') %}?search={{ request.args.get('search') }}{% endif %}">
+        {{ form.hidden_tag() }}
 
         <!-- Content Selection Section -->
         <div class="share-section">
@@ -43,35 +45,72 @@
             </div>
         </div>
 
-        <!-- Friend Search -->
-        <form method="GET" action="{{ url_for('main.share') }}" class="friend-search">
-            <input type="text" name="search" placeholder="Find your friend"
-                value="{{ request.args.get('search', '') }}">
-            <button type="submit" class="search-icon"><i class="fas fa-search"></i></button>
-        </form>
-
-
-
-        {{ form.hidden_tag() }}
-        <!-- Friend List -->
-        <div class="friend-list">
-            {% if friends %}
-            {% for friend in friends %}
-            <label class="option-label">
-                <input type="radio" name="selected_friend_id" value="{{ friend.id }}" required>
-                <span class="ms-2">{{ friend.first_name }} {{ friend.last_name }} ({{ friend.email }})</span>
-            </label>
-            {% endfor %}
-            {% else %}
-            <p class="text-muted">No matching friends found.</p>
-            {% endif %}
+        <!-- 3. 好友搜索 -->
+        <div class="friend-search mb-3">
+            <div class="input-group">
+                <input id="friendSearchInput" type="text" placeholder="Find your friend" class="form-control"
+                    value="{{ request.args.get('search','') }}">
+                <span class="input-group-text">
+                    <a id="friendSearchLink"
+                        href="{{ url_for('main.share') }}?search={{ request.args.get('search','') }}">
+                        <i class="fas fa-search"></i>
+                    </a>
+                </span>
+            </div>
         </div>
 
-        <!-- Action Buttons -->
-        <div class="action-buttons">
+
+        <!-- 4. 好友列表（JS 渲染进这里） -->
+        <!-- 4. 好友列表 -->
+<div id="friendListContainer" class="friend-list">
+    {% if friends %}
+      {% for friend in friends %}
+        <label class="option-label d-block">
+          <input
+            type="radio"
+            name="selected_friend_id"
+            value="{{ friend.id }}"
+            required
+          >
+          <span class="ms-2">
+            {{ friend.first_name }} {{ friend.last_name }} ({{ friend.email }})
+          </span>
+        </label>
+      {% endfor %}
+    {% elif request.args.get('search') %}
+      <p class="text-muted">No matching friends for “{{ request.args.get('search') }}”</p>
+    {% endif %}
+  </div>
+  
+        <!-- 5. 提交按钮（唯一的 submit） -->
+        <div class="action-buttons mt-3">
             <button type="submit" class="btn-confirm">Confirm</button>
             <a href="{{ url_for('main.dashboard') }}" class="btn-cancel">Cancel</a>
         </div>
     </form>
 </div>
+{% endblock %}
+{% block extra_js %}
+<script>
+    document.addEventListener('DOMContentLoaded', function () {
+        // 1. 拿到元素
+        const searchInput = document.getElementById('friendSearchInput');
+        const searchLink = document.getElementById('friendSearchLink');
+        const baseUrl = "{{ url_for('main.share') }}";
+
+        // 2. 更新 <a> 的 href
+        function updateSearchLink() {
+            const q = encodeURIComponent(searchInput.value.trim());
+            // 如果输入为空，就只跳转到 /share，否则带上 ?search=xxx
+            searchLink.href = q ? `${baseUrl}?search=${q}` : baseUrl;
+        }
+
+        // 3. 监听输入框变化
+        if (searchInput) {
+            searchInput.addEventListener('input', updateSearchLink);
+            // 初始化一次，防止页面初次有 search 参数时链接不对
+            updateSearchLink();
+        }
+    });
+</script>
 {% endblock %}

--- a/app/templates/share.html
+++ b/app/templates/share.html
@@ -61,26 +61,21 @@
 
 
         <!-- 4. 好友列表 -->
-<div id="friendListContainer" class="friend-list">
-    {% if friends %}
-      {% for friend in friends %}
-        <label class="option-label d-block">
-          <input
-            type="radio"
-            name="selected_friend_id"
-            value="{{ friend.id }}"
-            required
-          >
-          <span class="ms-2">
-            {{ friend.first_name }} {{ friend.last_name }} ({{ friend.email }})
-          </span>
-        </label>
-      {% endfor %}
-    {% elif request.args.get('search') %}
-      <p class="text-muted">No matching friends for “{{ request.args.get('search') }}”</p>
-    {% endif %}
-  </div>
-  
+        <div id="friendListContainer" class="friend-list">
+            {% if friends %}
+            {% for friend in friends %}
+            <label class="option-label d-block">
+                <input type="radio" name="selected_friend_id" value="{{ friend.id }}" required>
+                <span class="ms-2">
+                    {{ friend.first_name }} {{ friend.last_name }} ({{ friend.email }})
+                </span>
+            </label>
+            {% endfor %}
+            {% elif request.args.get('search') %}
+            <p class="text-muted">No matching friends for “{{ request.args.get('search') }}”</p>
+            {% endif %}
+        </div>
+
         <!-- 5. 提交按钮（唯一的 submit） -->
         <div class="action-buttons mt-3">
             <button type="submit" class="btn-confirm">Confirm</button>

--- a/app/templates/share.html
+++ b/app/templates/share.html
@@ -60,7 +60,6 @@
         </div>
 
 
-        <!-- 4. 好友列表（JS 渲染进这里） -->
         <!-- 4. 好友列表 -->
 <div id="friendListContainer" class="friend-list">
     {% if friends %}

--- a/app/templates/share_detail.html
+++ b/app/templates/share_detail.html
@@ -1,0 +1,13 @@
+{% extends "home_base.html" %}
+
+{% block title %}Shared Detail{% endblock %}
+{% block content %}
+<div class="share-detail">
+  <h2>Shared by {{ share.sender.first_name }} {{ share.sender.last_name }}</h2>
+  <p><strong>Content:</strong>
+    {% if share.content_type=='ranking' %}Ranking{% else %}{{ share.date_range|capitalize }}'s Calorie Intake{% endif %}
+  </p>
+  <p><strong>Shared at:</strong> {{ share.timestamp.strftime('%Y-%m-%d %H:%M') }}</p>
+  <a href="{{ url_for('main.sharing_list') }}">← Back to list</a>
+</div>
+{% endblock %}

--- a/app/templates/share_detail.html
+++ b/app/templates/share_detail.html
@@ -1,13 +1,62 @@
 {% extends "home_base.html" %}
 
-{% block title %}Shared Detail{% endblock %}
+{% block title %}DailyBite - Shared Detail{% endblock %}
+
+{% block extra_css %}
+<link rel="stylesheet" href="{{ url_for('static', filename='style_sharing_list.css') }}">
+<style>
+  .share-detail {
+    max-width: 600px;
+    margin: 2rem auto;
+    padding: 1rem;
+  }
+
+  .share-detail h2 {
+    font-size: 1.75rem;
+    margin-bottom: 1rem;
+  }
+
+  .share-detail p {
+    margin-bottom: 0.75rem;
+  }
+</style>
+{% endblock %}
+
 {% block content %}
 <div class="share-detail">
-  <h2>Shared by {{ share.sender.first_name }} {{ share.sender.last_name }}</h2>
-  <p><strong>Content:</strong>
-    {% if share.content_type=='ranking' %}Ranking{% else %}{{ share.date_range|capitalize }}'s Calorie Intake{% endif %}
+  <h2>Shared By {{ share.sender.first_name }} {{ share.sender.last_name }}</h2>
+
+  <p>
+    <strong>Content:</strong>
+    {% if share.content_type == 'ranking' %}
+    {{ share.sender.first_name }}' current ranking
+    {% else %}
+    {{ share.date_range|capitalize }}'s Calorie Intake
+    {% endif %}
   </p>
-  <p><strong>Shared at:</strong> {{ share.timestamp.strftime('%Y-%m-%d %H:%M') }}</p>
-  <a href="{{ url_for('main.sharing_list') }}">← Back to list</a>
+
+  <p>
+    <strong>Period:</strong>
+    {% if share.date_range == 'daily' %}
+    {{ period_start.strftime('%Y-%m-%d') }}
+    {% else %}
+    {{ period_start.strftime('%Y-%m-%d') }}
+    &ndash;
+    {{ period_end.strftime('%Y-%m-%d') }}
+    {% endif %}
+  </p>
+
+  {% if share.content_type == 'calorie' %}
+  <div class="calorie-details">
+    <!-- TODO: 渲染实际的数据 -->
+    <em>Calorie data for {{ share.date_range }} would appear here.</em>
+  </div>
+  {% endif %}
+
+  <div class="mt-4">
+    <a href="{{ url_for('main.sharing_list') }}" class="btn btn-secondary">
+      ← Back to Sharing List
+    </a>
+  </div>
 </div>
 {% endblock %}

--- a/app/templates/sharing_list.html
+++ b/app/templates/sharing_list.html
@@ -12,32 +12,33 @@
 
 <div class="sharing-list-container">
     {% if shares %}
-        {% for share in shares %}
-        <!-- V：让整个 .sharing-item 可点击 查看详情 -->
-        <a href="{{ url_for('main.sharin_list', share_id=share.id) }}" class="sharing-item-link"> 
-            <div class="sharing-item">
-                <div class="sharing-avatar">
-                    <i class="fa-solid fa-user fa-lg"></i>
-                </div>
-                <div class="sharing-content">
-                    <div class="sharing-user">{{ share.sender.username }}</div>
-                    <div class="sharing-text">
-                        Shared you a 
-                        {% if share.content_type == 'ranking' %}
-                            Ranking.
-                        {% elif share.content_type == 'calorie' %}
-                            {{ share.date_range|capitalize }}'s Calorie Intake
-                        {% endif %}
-                    </div>
-                </div>
-                <div class="sharing-time">{{ share.elapsed_time }}</div>
+    {% for share in shares %}
+    <!-- V：让整个 .sharing-item 可点击 查看详情 -->
+    <a href="{{ url_for('main.view_share', share_id=share.id) }}"
+        class="sharing-item-link {% if not share.is_read %}unread{% endif %}">
+        <div class="sharing-item">
+            <div class="sharing-avatar">
+                <i class="fa-solid fa-user fa-lg"></i>
             </div>
-        </a>
-        {% endfor %}
-    {% else %}
-        <div class="no-shares">
-            <p class="text-muted text-center my-5">No shared content yet.</p>
+            <div class="sharing-content">
+                <div class="sharing-user">{{ share.sender.first_name }} {{ share.sender.last_name }}</div>
+                <div class="sharing-text">
+                    Shared you a
+                    {% if share.content_type == 'ranking' %}
+                    Ranking.
+                    {% elif share.content_type == 'calorie' %}
+                    {{ share.date_range|capitalize }}'s Calorie Intake
+                    {% endif %}
+                </div>
+            </div>
+            <div class="sharing-time">{{ share.elapsed_time }}</div>
         </div>
+    </a>
+    {% endfor %}
+    {% else %}
+    <div class="no-shares">
+        <p class="text-muted text-center my-5">No shared content yet.</p>
+    </div>
     {% endif %}
 </div>
 {% endblock %}

--- a/app/templates/sharing_list.html
+++ b/app/templates/sharing_list.html
@@ -14,7 +14,7 @@
     {% if shares %}
         {% for share in shares %}
         <!-- V：让整个 .sharing-item 可点击 查看详情 -->
-        <a href="{{ url_for('main.view_share', share_id=share.id) }}" class="sharing-item-link"> 
+        <a href="{{ url_for('main.sharin_list', share_id=share.id) }}" class="sharing-item-link"> 
             <div class="sharing-item">
                 <div class="sharing-avatar">
                     <i class="fa-solid fa-user fa-lg"></i>


### PR DESCRIPTION
## What changed

1. **Fixed nested form & share recording**

   * Resolved the “search friends nested form” issue so the AJAX-powered friend search lives inside the global modal rather than a separate page.
   * Updated the `/share` route to correctly persist each share action into the `ShareRecord` table.

2. **Unread flag & message badge**

   * Added an `is_read` column on `ShareRecord` and a navbar bell icon showing the unread count via a context processor.
   * Updated the share-list UI to highlight unread items and mark them read when opened.

3. **Share detail page**

   * Created a new `view_share` endpoint and `share_detail.html` template to display the shared content’s details and its date-range period.

4. **Global share pop-up**

   * Implemented a Bootstrap modal in `home_base.html` (and `share_modal.js`) for in-context sharing on any page.
   * The modal supports selecting content type (ranking/calories), date range (daily/weekly/monthly), AJAX friend search, and seamless POST back to the `/share` endpoint.

---

## Issues

* The old standalone `share.html` page has not been used in favor of the global modal.
* Still need fix to use Flash errors when in the Sharing Pop-Up model.
---

## Database Notice

If you’re using a fresh database, also re-seed initial data:

```bash
python seed.py
```
