### PR TITLE
fixed: inject ShareForm into template context to resolve undefined ‘form’

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -33,6 +33,12 @@ def create_app(config_class=Config):
             cnt = 0
         return {'unread_share_count': cnt}
 
+    # Inject the global ShareForm instance
+    @app.context_processor
+    def inject_share_form():
+        from app.forms import ShareForm
+        return {'form': ShareForm()}
+    
     from app.routes.auth import bp as auth_bp
     app.register_blueprint(auth_bp, url_prefix='/auth')
 


### PR DESCRIPTION
- Add a `@app.context_processor` in `create_app` to always inject `ShareForm()` as `form`
- Ensures `{{ form.hidden_tag() }}` in the global share modal never fails, even on pages like settings
- Deferred importing ShareForm inside the inject_share_form context processor