### PR TITLE
 Sharing Feature：Nutrition Type, Detail-Page Charts & Modal Search

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -82,8 +82,9 @@ class AddNewProductForm(FlaskForm):
 class ShareForm(FlaskForm):
     search = StringField('Search Friend')
     content_type = RadioField('Content Type', choices=[
-        ('ranking', 'My Current Ranking'),
-        ('calorie', 'My Calorie Intake')
+       ('ranking', 'My Current Ranking'),
+        ('calorie', 'My Calorie Intake'),
+        ('nutrition',  'My Nutrition Intake'),
     ], validators=[DataRequired()])
 
     date_range = RadioField('Date Range', choices=[

--- a/app/models.py
+++ b/app/models.py
@@ -125,7 +125,7 @@ class ShareRecord(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     sender_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
     receiver_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
-    content_type = db.Column(db.String(20), nullable=False)   # 'ranking' or 'calorie'
+    content_type = db.Column(db.String(20), nullable=False)   # 'ranking' or 'calorie' or 'nutrition'
     date_range = db.Column(db.String(20), nullable=False)     # 'daily', 'weekly', 'monthly'
     timestamp = db.Column(db.DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
     is_read = db.Column(db.Boolean, default=False) # 用于消息提醒系统

--- a/app/static/share_modal.js
+++ b/app/static/share_modal.js
@@ -1,78 +1,118 @@
-// static/share_modal.js
-;(function(){
-  // 1. 找到 Modal 元素并实例化
-  const shareModalEl = document.getElementById('shareModal');
-  if (!shareModalEl) return;
-  const shareModal = new bootstrap.Modal(shareModalEl);
+; (function () {
+  document.addEventListener('DOMContentLoaded', function () {
+    console.log('share_modal.js loaded');
+    const shareModalEl = document.getElementById('shareModal');
+    console.log('modal el:', shareModalEl);
 
-  // 2. 触发按钮：侧边栏那个 link
-  const trigger = document.querySelector('a[data-bs-target="#shareModal"]');
-  if (trigger) {
-    trigger.addEventListener('click', function(e){
-      e.preventDefault();
-      // 每次打开前清空搜索框和结果
-      const input = document.getElementById('friendSearchInput');
-      const list  = document.getElementById('friendListContainerGlobal');
-      if (input) input.value = '';
-      if (list)  list.innerHTML = '';
-      shareModal.show();
-    });
-  }
+    if (!shareModalEl) return;
+    const shareModal = new bootstrap.Modal(shareModalEl);
 
-  // 3. 搜索相关元素
-  const input         = document.getElementById('friendSearchInput');
-  const btn           = document.getElementById('friendSearchBtn');
-  const listContainer = document.getElementById('friendListContainerGlobal');
-  // 这里的 URL 要跟你的 Flask 路由保持一致
-  const baseUrl       = window.SHARE_MODAL_BASE_URL;
-
-  if (!input || !btn || !listContainer || !baseUrl) {
-    console.error('Share modal: missing elements or baseUrl');
-    return;
-  }
-
-  // 4. 渲染函数
-  function renderFriends(users) {
-    if (!users.length) {
-      listContainer.innerHTML = `<p class="text-muted">
-        No matching friends for “${input.value.trim()}”
-      </p>`;
-      return;
-    }
-    listContainer.innerHTML = users.map(u => `
-      <label class="list-group-item">
-        <input class="form-check-input me-2" type="radio"
-               name="selected_friend_id"
-               value="${u.id}" required>
-        ${u.first_name} ${u.last_name} (${u.email})
-      </label>
-    `).join('');
-  }
-
-  // 5. 点击搜索
-  btn.addEventListener('click', async function(){
-    const q = input.value.trim();
-    if (!q) {
-      listContainer.innerHTML = '';
-      return;
-    }
-    try {
-      const resp = await fetch(`${baseUrl}?search=${encodeURIComponent(q)}`, {
-        headers: { 'Accept': 'application/json' }
+    // 2. 触发按钮
+    const trigger = document.querySelector('a[data-bs-target="#shareModal"]');
+    console.log('trigger el:', trigger);
+    if (trigger) {
+      trigger.addEventListener('click', function (e) {
+        e.preventDefault();
+        // 每次打开前清空搜索框和结果
+        const input = shareModalEl.querySelector('#friendSearchInput');
+        const list  = shareModalEl.querySelector('#friendListContainerGlobal');
+        if (input) input.value = '';
+        if (list)  list.innerHTML = '';
+        updateRanges();    // 打开时先更新一次周期显示
+        shareModal.show();
       });
-      if (!resp.ok) throw new Error(resp.status);
-      const users = await resp.json();
-      renderFriends(users);
-    } catch (err) {
-      console.error('Share modal search error', err);
     }
-  });
 
-  // 6. 回车触发搜索
-  input.addEventListener('keydown', function(e){
-    if (e.key === 'Enter') {
-      e.preventDefault();
-      btn.click();
+    // 3. 搜索相关元素
+    const formEl         = shareModalEl.querySelector('form');
+    const baseUrl        = formEl.getAttribute('action');
+    const input          = shareModalEl.querySelector('#friendSearchInput');
+    const btn            = shareModalEl.querySelector('#friendSearchBtn');
+    const listContainer  = shareModalEl.querySelector('#friendListContainerGlobal');
+
+    if (!formEl || !baseUrl || !input || !btn || !listContainer) {
+      console.error('Share modal: missing form/action or elements', {
+        formEl, baseUrl, input, btn, listContainer
+      });
+      return;
     }
+
+    // 4. 渲染函数
+    function renderFriends(users, query) {
+      if (!users.length) {
+        listContainer.innerHTML = `<p class="text-muted">
+          No matching friends for “${query}”
+        </p>`;
+        return;
+      }
+      listContainer.innerHTML = users.map(u => `
+        <label class="list-group-item">
+          <input class="form-check-input me-2" type="radio"
+                 name="selected_friend_id"
+                 value="${u.id}" required>
+          ${u.first_name} ${u.last_name} (${u.email})
+        </label>
+      `).join('');
+    }
+
+    // 5. 点击搜索
+    async function doSearch() {
+      const q = input.value.trim();
+      if (!q) {
+        listContainer.innerHTML = '';
+        return;
+      }
+      try {
+        const url  = `${baseUrl}?search=${encodeURIComponent(q)}`;
+        const resp = await fetch(url, {
+          headers: { 'Accept': 'application/json' }
+        });
+        if (!resp.ok) throw new Error(`Status ${resp.status}`);
+        const users = await resp.json();
+        renderFriends(users, q);
+      } catch (err) {
+        console.error('Share modal search error', err);
+        listContainer.innerHTML = `<p class="text-danger">
+          Search failed. See console.
+        </p>`;
+      }
+    }
+
+    btn.addEventListener('click', function (e) {
+      e.preventDefault();
+      doSearch();
+    });
+    input.addEventListener('keydown', function (e) {
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        doSearch();
+      }
+    });
+
+    // —— 7. 动态控制 “周期” 选项 —— 
+    const typeRadios    = shareModalEl.querySelectorAll('input[name="content_type"]');
+    const rangeWrappers = shareModalEl.querySelectorAll('[data-range]');
+
+    function updateRanges() {
+      const selected = shareModalEl.querySelector('input[name="content_type"]:checked').value;
+      rangeWrappers.forEach(w => {
+        const r = w.getAttribute('data-range'); // 'day' / 'week' / 'month'
+        if (selected === 'ranking') {
+          w.style.display = (r === 'week' || r === 'month') ? '' : 'none';
+        } else {
+          w.style.display = '';
+        }
+      });
+      // 隐藏的如果是已选中的，就选第一个可见的
+      const checked = shareModalEl.querySelector('input[name="date_range"]:checked');
+      if (checked && checked.closest('[data-range]').style.display === 'none') {
+        const firstVisible = Array.from(rangeWrappers).find(w => w.style.display !== 'none');
+        if (firstVisible) firstVisible.querySelector('input').checked = true;
+      }
+    }
+
+    typeRadios.forEach(radio => radio.addEventListener('change', updateRanges));
+    // 初始一次
+    updateRanges();
   });
 })();

--- a/app/templates/home_base.html
+++ b/app/templates/home_base.html
@@ -72,7 +72,7 @@
                             <i class="fa-solid fa-users"></i>
                         </a>
                         <a href="{{ url_for('main.sharing_list') }}"
-                            class="nav-icon {% if request.endpoint == 'main.sharin_list' %}active{% endif %}">
+                            class="nav-icon {% if request.endpoint == 'main.sharing_list' %}active{% endif %}">
                             <i class="fa-solid fa-list"></i>
                         </a>
                     </div>
@@ -105,38 +105,43 @@
 
                                 <!-- 1. 图表类型（内容类型） -->
                                 <fieldset class="mb-3">
-                                    <legend class="form-label">Select content to share</legend>
+                                    <legend class="form-label">Select Chart Type</legend>
                                     <div class="form-check">
-                                        <input class="form-check-input" type="radio" name="content_type" value="ranking"
-                                            id="ctRanking" checked>
-                                        <label class="form-check-label" for="ctRanking">My Current Ranking</label>
+                                        <input class="form-check-input" type="radio" name="content_type"
+                                            id="ctCalorieLine" value="calorie" checked>
+                                        <label class="form-check-label" for="ctCalorieLine">My Calorie Intake</label>
                                     </div>
                                     <div class="form-check">
-                                        <input class="form-check-input" type="radio" name="content_type" value="calorie"
-                                            id="ctCalorie">
-                                        <label class="form-check-label" for="ctCalorie">My Calorie Intake</label>
+                                        <input class="form-check-input" type="radio" name="content_type"
+                                            id="ctNutritionPie" value="nutrition">
+                                        <label class="form-check-label" for="ctNutritionPie">My Nutrition Intake</label>
+                                    </div>
+                                    <div class="form-check">
+                                        <input class="form-check-input" type="radio" name="content_type"
+                                            id="ctLeaderboard" value="ranking">
+                                        <label class="form-check-label" for="ctLeaderboard">My Current Ranking</label>
                                     </div>
                                 </fieldset>
 
-                                <!-- 2. 周期选择 -->
                                 <fieldset class="mb-3">
                                     <legend class="form-label">Select Data Range</legend>
-                                    <div class="form-check form-check-inline">
+                                    <div class="form-check form-check-inline" data-range="day">
                                         <input class="form-check-input" type="radio" name="date_range" id="drDaily"
-                                            value="daily">
+                                            value="day">
                                         <label class="form-check-label" for="drDaily">Daily</label>
                                     </div>
-                                    <div class="form-check form-check-inline">
+                                    <div class="form-check form-check-inline" data-range="week">
                                         <input class="form-check-input" type="radio" name="date_range" id="drWeekly"
-                                            value="weekly" checked>
+                                            value="week" checked>
                                         <label class="form-check-label" for="drWeekly">Weekly</label>
                                     </div>
-                                    <div class="form-check form-check-inline">
+                                    <div class="form-check form-check-inline" data-range="month">
                                         <input class="form-check-input" type="radio" name="date_range" id="drMonthly"
-                                            value="monthly">
+                                            value="month">
                                         <label class="form-check-label" for="drMonthly">Monthly</label>
                                     </div>
                                 </fieldset>
+
 
                                 <!-- 3. 好友搜索 -->
                                 <div class="input-group mb-3">
@@ -154,8 +159,8 @@
                             </form>
                         </div>
                         <div class="modal-footer">
-                            <button form="shareFormGlobal" type="submit" class="btn btn-primary">Confirm</button>
                             <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                            <button form="shareFormGlobal" type="submit" class="btn btn-primary">Share</button>
                         </div>
                     </div>
                 </div>
@@ -175,7 +180,7 @@
     </script>
 
     <script src="{{ url_for('static', filename='share_modal.js') }}" defer></script>
-  
+
     {% block extra_js %}{% endblock %}
 
 

--- a/app/templates/share_detail.html
+++ b/app/templates/share_detail.html
@@ -1,62 +1,78 @@
+{# share_detail.html #}
 {% extends "home_base.html" %}
-
-{% block title %}DailyBite - Shared Detail{% endblock %}
-
 {% block extra_css %}
-<link rel="stylesheet" href="{{ url_for('static', filename='style_sharing_list.css') }}">
-<style>
-  .share-detail {
-    max-width: 600px;
-    margin: 2rem auto;
-    padding: 1rem;
-  }
-
-  .share-detail h2 {
-    font-size: 1.75rem;
-    margin-bottom: 1rem;
-  }
-
-  .share-detail p {
-    margin-bottom: 0.75rem;
-  }
-</style>
+<link rel="stylesheet" href="{{ url_for('static', filename='style_sharing_detail.css') }}">
 {% endblock %}
 
 {% block content %}
-<div class="share-detail">
-  <h2>Shared By {{ share.sender.first_name }} {{ share.sender.last_name }}</h2>
-
-  <p>
-    <strong>Content:</strong>
-    {% if share.content_type == 'ranking' %}
-    {{ share.sender.first_name }}' current ranking
-    {% else %}
-    {{ share.date_range|capitalize }}'s Calorie Intake
-    {% endif %}
+<div class="p-4">
+  <h3>Shared by {{ share.sender.first_name }} {{ share.sender.last_name }}</h3>
+  <p><strong>Period:</strong>
+     {{ period_start }}{% if share.date_range!='daily' %} – {{ period_end }}{% endif %}
   </p>
 
-  <p>
-    <strong>Period:</strong>
-    {% if share.date_range == 'daily' %}
-    {{ period_start.strftime('%Y-%m-%d') }}
-    {% else %}
-    {{ period_start.strftime('%Y-%m-%d') }}
-    &ndash;
-    {{ period_end.strftime('%Y-%m-%d') }}
-    {% endif %}
-  </p>
 
-  {% if share.content_type == 'calorie' %}
-  <div class="calorie-details">
-    <!-- TODO: 渲染实际的数据 -->
-    <em>Calorie data for {{ share.date_range }} would appear here.</em>
-  </div>
-  {% endif %}
+  {# 2. 渲染图表容器 #}
+  <div id="chartContainer" style="height:350px;"></div>
 
-  <div class="mt-4">
-    <a href="{{ url_for('main.sharing_list') }}" class="btn btn-secondary">
-      ← Back to Sharing List
-    </a>
-  </div>
+  <a href="{{ url_for('main.sharing_list') }}" class="btn btn-secondary mt-3">
+    ← Back to Sharing List
+  </a>
 </div>
+{% endblock %}
+
+{% block extra_js %}
+<script src="https://cdn.jsdelivr.net/npm/echarts@5.5.0/dist/echarts.min.js"></script>
+
+<script>
+  console.log(' share_detail.js loaded');
+
+  document.addEventListener('DOMContentLoaded', function(){
+    console.log('DOMContentLoaded in share_detail');
+
+    const type  = "{{ share.content_type }}";   // 'calorie','nutrition' 或 'ranking'
+    const range = "{{ share.date_range }}";     // 'daily','weekly','monthly'
+    const start = "{{ period_start.isoformat() }}";
+    const dom   = document.getElementById('chartContainer');
+    console.log('share.content_type=', type, ' share.date_range=', range, ' chartContainer=', dom);
+
+    if (!dom) {
+      console.error('chartContainer not found!');
+      return;
+    }
+
+    const chart = echarts.init(dom);
+    console.log('✔ echarts.init done');
+
+  
+    if (type === 'calorie') {
+      console.log('→ will fetch calorie chart with range', range);
+      fetch(`/api/get_calorie_chart_options?range=${range}`, {headers:{Accept:'application/json'}})
+        .then(r=> { console.log('calorie response status', r.status); return r.json() })
+        .then(opts=> { console.log('calorie opts', opts); chart.setOption(opts) })
+        .catch(e=> console.error('❌ calorie error', e));
+    }
+    else if (type === 'nutrition') {
+      fetch(`/api/nutrition_ratio?date=${start}&range=${range}`, {headers:{Accept:'application/json'}})
+        .then(r => r.json()).then(opts => chart.setOption(opts))
+        .catch(() => dom.innerHTML = '<p class="text-danger text-center">Cannot load this chart.</p>');
+    }
+    else if (type === 'ranking') {
+      fetch(`/api/goal_leaderboard/${range}`, {headers:{Accept:'application/json'}})
+        .then(r => r.json())
+        .then(data => {
+          let html = `<table class="table"><thead><tr><th>Ranking</th><th>Name</th><th>Days</th></tr></thead><tbody>${
+            data.map(u=>`<tr>
+              <td>${u.rank}</td>
+              <td>${u.last_name}</td>
+              <td>${u.days_achieved}</td>
+            </tr>`).join('')
+          }</tbody></table>`;
+          dom.innerHTML = html;
+        })
+        .catch(() => dom.innerHTML = '<p class="text-danger text-center">Cannot load this chart.</p>');
+    }
+  });
+  </script>
+
 {% endblock %}

--- a/app/templates/sharing_list.html
+++ b/app/templates/sharing_list.html
@@ -23,11 +23,26 @@
             <div class="sharing-content">
                 <div class="sharing-user">{{ share.sender.first_name }} {{ share.sender.last_name }}</div>
                 <div class="sharing-text">
-                    Shared you a
-                    {% if share.content_type == 'ranking' %}
-                    Ranking.
-                    {% elif share.content_type == 'calorie' %}
-                    {{ share.date_range|capitalize }}'s Calorie Intake
+                    {% set dr = share.date_range %}
+                    {% set ct = share.content_type %}
+                    {% if dr == 'day' and ct == 'calorie' %}
+                        shared with you today’s calorie intake.
+                    {% elif dr == 'day' and ct == 'nutrition' %}
+                        shared with you today’s nutrition intake.
+                    {% elif dr == 'week' and ct == 'ranking' %}
+                        shared with you this week’s ranking.
+                    {% elif dr == 'week' and ct == 'calorie' %}
+                        shared with you this week’s calorie intake.
+                    {% elif dr == 'week' and ct == 'nutrition' %}
+                        shared with you this week’s nutrition intake.
+                    {% elif dr == 'month' and ct == 'ranking' %}
+                        shared with you this month’s ranking.
+                    {% elif dr == 'month' and ct == 'calorie' %}
+                        shared with you this month’s calorie intake.
+                    {% elif dr == 'month' and ct == 'nutrition' %}
+                        shared with you this month’s nutrition intake.
+                    {% else %}
+                        shared some data with you.
                     {% endif %}
                 </div>
             </div>


### PR DESCRIPTION
****What Changed**

* **New “nutrition” share type**

  * Added `nutrition` option alongside `calorie` and `ranking` throughout the share form, share list, and detail pages.
  * Updated `sharing_list.html` to render natural-language text for Nutrition shares.
* **Refactored Jinja templates**

  * Flattened the nested `{% if %}` blocks in `sharing_list.html` to a single `if/elif/endif` chain for readability and correct syntax.
* **Improved Share Detail charts**

  * Modified the chart-initialization script to map `daily/weekly/monthly` → `day/week/month` for the calorie endpoint, and to only send `date` for nutrition.
  * Unified the ranking endpoint to `/api/goal_leaderboard/<range>` so the front end no longer needs special-case logic.
* **Fixed modal friend search**

  * Corrected a typo (`fromEL` → `formEl`) in `share_modal.js` and now dynamically reads the form’s `action` URL.
  * Added console-logging and proper element selectors so the AJAX search fires correctly and renders results.
* **Dynamic date-range toggling**

  * When “My Current Ranking” is selected in the share modal, only “Weekly” and “Monthly” options remain; “Daily” hides automatically.

**Issues**
Have fixed the last `shareToFriends` pr remained question about " no search content input warming pop-up"

**Database Migration**
None required—no schema changes.

**Testing & Verification**
1. Open share modal → search friends by name/email → select and share each of the three content types.
2. Confirm share list shows correct, natural-language descriptions for calorie, nutrition, and ranking.
3. Click into a share detail → verify the correct chart/table loads without manual toggles.
4. Review browser console/network tab to ensure all AJAX calls succeed.
