### PR TITLE
fix(addMeal): persist full datetime (including hours, minutes, second…

### DIFF
--- a/app/routes/main.py
+++ b/app/routes/main.py
@@ -471,6 +471,7 @@ def addMeal():
 @login_required
 def addMealPost():
     form = AddMealForm()
+    
     print(f"Inside /addMeal GET route, choices are: {form.mealType.choices}")
     if form.validate_on_submit():
         foodName = form.food.data
@@ -484,9 +485,14 @@ def addMealPost():
             
         # Create and add new food log entry
         inputFoodID = inputFood.id
-        foodLog = FoodLog(user_id = current_user.id, food_item_id = inputFoodID, meal_type = form.mealType.data, quantity_consumed = form.quantity.data, unit_consumed = form.unit.data)
+        log_date = db.Column(
+            db.DateTime(timezone=True),
+            nullable=False,
+            default=lambda: datetime.now(timezone.utc)
+        )
+        foodLog = FoodLog(user_id = current_user.id, food_item_id = inputFoodID, log_date=datetime.now(timezone.utc), meal_type = form.mealType.data, quantity_consumed = form.quantity.data, unit_consumed = form.unit.data)
         db.session.add(foodLog)
-        db.session.commit()
+        db.session.commit() 
         flash(f"Your meal added successfully!", 'success')
         return redirect(url_for('main.dashboard'))
     else:

--- a/app/templates/dashboard_home.html
+++ b/app/templates/dashboard_home.html
@@ -14,9 +14,9 @@
 
 {% block content %}
 
-<div class="row">
+<div class="row row-cols-1 row-cols-md-2 g-4">
     <!-- Calorie Intake Chart -->
-    <div class="col-md-6 mb-4">
+    <div class="col">
         <div class="card">
             <div class="card-header d-flex justify-content-between align-items-center">
                 <h5 class="mb-0">Calorie Intake Trend</h5>
@@ -32,27 +32,12 @@
         </div>
     </div>
 
-    <!-- Nutrition Breakdown Chart -->
-    <div class="col-md-6 mb-4">
-        <div class="card">
-            <div class="card-header d-flex justify-content-between align-items-center">
-             <h5 class="mb-0">Nutrition Ratio (Today, kcal %)</h5>
-                </div>
-            </div>
-            <div class="card-body">
-                <div class="chart-placeholder">
-                    <div id="nutritionRatioChart" style="height: 250px; width: 100%;"></div>
-                </div>
-            </div>
-        </div>
-    </div>
-
-    <!-- Leaderboard -->
-    <div class="row">
+    <!-- Goal Achievement Ranking -->
+    <div class="col">
         <div class="col-md-6 mb-4">
             <div class="card">
                 <div class="card-header d-flex justify-content-between align-items-center">
-                    <h5 class="mb-0">Goal Achievement Leaderboard</h5>
+                    <h5 class="mb-0">Goal Achievement Ranking</h5>
                     <div class="btn-group btn-group-sm leaderboard-toggle" role="group">
                         <button type="button" class="btn btn-primary active leaderboard-period-btn" data-period="7d">Last 7 Days</button>
                         <button type="button" class="btn btn-outline-primary leaderboard-period-btn" data-period="30d">Last 30 Days</button>
@@ -70,8 +55,23 @@
         </div>
     </div>
 
+    <!-- Nutrition Breakdown Chart -->
+    <div class="col">
+        <div class="card">
+            <div class="card-header d-flex justify-content-between align-items-center">
+             <h5 class="mb-0">Nutrition Ratio (kcal %)</h5>
+                
+            </div>
+            <div class="card-body">
+                <div class="chart-placeholder">
+                    <div id="nutritionRatioChart" style="height: 250px; width: 100%;"></div>
+                </div>
+            </div>
+        </div>
+    </div>
+
     <!-- Recent Activity -->
-    <div class="col-md-6 mb-4">
+    <div class="col">
         <div class="card">
             <div class="card-header d-flex justify-content-between align-items-center">
                 <h5 class="mb-0">Recent Activity</h5>
@@ -87,7 +87,7 @@
                             <span class="text-muted small ms-1">({{ log.meal_type }})</span>
                         </div>
                         <div class="activity-time text-muted small">
-                            {{ log.log_date.strftime('%H:%M') if log.log_date else '' }}
+                            {{ log.log_date.strftime('%m-%d %H:%M') if log.log_date else '' }}
                         </div>
                     </div>
                     {% endfor %}


### PR DESCRIPTION
## What changed
- Change `FoodLog.log_date` column to `DateTime` with a default of `datetime.utcnow`
- In `addMealPost`, explicitly set `log_date=datetime.utcnow()` when creating a new log
- Add and run a migration to alter the column type if necessary