### PR TITLE
Make Login Email Case-Insensitive

### DIFF
--- a/app/routes/auth.py
+++ b/app/routes/auth.py
@@ -11,13 +11,17 @@ bp = Blueprint('auth', __name__)
 @bp.route('/login', methods=['GET', 'POST'])
 def login():
     if current_user.is_authenticated:
-        return redirect(url_for('main.index')) 
+        return redirect(url_for('main.dashboard'))
 
     form = LoginForm()
+
     if form.validate_on_submit():
-        user = User.query.filter_by(email=form.emailLogin.data).first() 
+        submitted_email_original = form.emailLogin.data
+        submitted_email_normalized = submitted_email_original.lower()
+        user = User.query.filter_by(email=submitted_email_normalized).first()
+
         if user is None or not user.check_password(form.passwordLogin.data):
-            flash('Invalid email or password', 'danger')
+            flash('Invalid email or password.', 'danger')
             return redirect(url_for('auth.login'))
 
         login_user(user, remember=form.remember_me.data)


### PR DESCRIPTION
#### What Changed
- Updated the `/login` route to normalize the submitted email to lowercase before querying the database.
- This prevents login failures caused by case mismatches between user input and stored email addresses.

#### Why
- Email addresses are case-insensitive in most real-world scenarios.
- Without normalization, users might fail to log in if they enter uppercase characters, even if their account exists.

---

### Impact
- Improved login reliability and user experience.
- No database changes involved—purely a backend logic update.