### PR TITLE
Fix: fallback to default FoodItem suggestions and default MealType

### DIFF
--- a/app/routes/main.py
+++ b/app/routes/main.py
@@ -492,7 +492,7 @@ def addMeal():
     if historyItemsID:
         historyItemsNames = db.session.execute(select(FoodItem.name).where(FoodItem.id.in_(historyItemsID))).scalars().all()
 
-    admin = User.query.filter_by(email='admin@DailyBite.com').first()
+    admin = User.query.filter_by(email='admin@dailybite.com').first()
     suggestion_filter = None
     if hasattr(FoodItem, 'user_id'):
          suggestion_filter_user = (FoodItem.user_id == current_user.id)
@@ -615,7 +615,7 @@ def settings():
     form3 = AddNewProductForm()
     edit_profile_form = EditProfileForm()
     
-    admin = User.query.filter_by(email='admin@DailyBite.com').first()
+    admin = User.query.filter_by(email='admin@dailybite.com').first()
 
     meal_types = (
         MealType.query

--- a/seed.py
+++ b/seed.py
@@ -55,11 +55,18 @@ with app.app_context():
     try:
         db.session.commit()
         print("Seeded/Updated users.")
+        default_meal_type_names = ["Breakfast", "Lunch", "Dinner", "Snacks"]
+        for mt_name in default_meal_type_names:
+            exists = MealType.query.filter_by(user_id=admin.id, type_name=mt_name).first()
+            if not exists:
+                mt = MealType(user_id=admin.id, type_name=mt_name)
+                db.session.add(mt)
+                print(f"Default meal type '{mt_name}' created for admin.")
+        db.session.commit()
     except Exception as e:
         db.session.rollback()
         print(f"Error seeding/updating users: {e}")
 
-    default_meal_type_names = ["Breakfast", "Lunch", "Dinner", "Snacks"]
     for name in default_meal_type_names:
         existing_system_type = MealType.query.filter_by(type_name=name, user_id=None).first()
         if not existing_system_type:


### PR DESCRIPTION
**What’s changed:**

1. **Add Meal route (`addMeal` view)**

   * When both personalized and admin-based `FoodItem` suggestions are not empty, display the top 10.
2. **Seed script (`seed.py`)**

   * After ensuring the admin user exists, automatically seed four default `MealType` records (“Breakfast”, “Lunch”, “Dinner”, “Snacks”) under the admin account.

**How to test:**

1. **Apply database migrations**

   ```bash
   flask db upgrade
   ```
2. **Re-seed initial data**

   ```bash
   python seed.py
   ```
3. **Verify in the database**

   * `alembic_version` matches the latest migration.
   * The `user` table includes the `admin@dailybite.com` user.
   * The `meal_type` table contains “Breakfast”, “Lunch”, “Dinner”, “Snacks” with `user_id` pointing to the admin user.
4. **MealType dropdown**

   * On **Add Meal**, confirm the MealType dropdown lists the four seeded types.
