### PR TITLE
leaderboard correctly handles tied ranks and displays only top 3

### DIFF
--- a/app/templates/dashboard_home.html
+++ b/app/templates/dashboard_home.html
@@ -336,29 +336,39 @@
                             </p>
                         `;
                     } else {
-                        leaderboardData.slice(0, 3).forEach((entry, index) => {
+                        const medals = ['🥇', '🥈', '🥉'];
+                        const medalRankMap = {};  // 映射 rank -> medal index（最多3个）
+                        let medalAssigned = 0;
+
+                        leaderboardData.forEach(entry => {
+                            // 最多只处理三种不同 rank
+                            if (!(entry.rank in medalRankMap)) {
+                                if (medalAssigned >= 3) return; // 超过前三名，直接不渲染
+                                medalRankMap[entry.rank] = medalAssigned;
+                                medalAssigned += 1;
+                            }
+
+                            const medalIndex = medalRankMap[entry.rank];
+
                             const listItem = document.createElement('li');
                             listItem.className = 'list-group-item d-flex justify-content-between align-items-center py-3';
-                            
+
                             const nameDiv = document.createElement('div');
                             nameDiv.className = 'ms-2 me-auto';
 
                             const rankSpan = document.createElement('span');
                             rankSpan.className = 'me-3';
                             rankSpan.style.fontSize = '1.1em';
-
-                            // 🥇🥈🥉 只给前3加奖牌
-                            const medals = ['🥇', '🥈', '🥉'];
-                            rankSpan.textContent = medals[index] || '';
+                            rankSpan.textContent = medals[medalIndex] || '';
 
                             nameDiv.appendChild(rankSpan);
                             nameDiv.appendChild(document.createTextNode(entry.full_name || 'Unknown User'));
 
                             const badge = document.createElement('span');
                             let badgeClass = 'bg-secondary';
-                            if (index === 0) badgeClass = 'bg-warning text-dark';
-                            else if (index === 1) badgeClass = 'bg-info text-dark';
-                            else if (index === 2) badgeClass = 'bg-success';
+                            if (medalIndex === 0) badgeClass = 'bg-warning text-dark';
+                            else if (medalIndex === 1) badgeClass = 'bg-info text-dark';
+                            else if (medalIndex === 2) badgeClass = 'bg-success';
 
                             badge.className = `badge ${badgeClass} rounded-pill`;
                             badge.textContent = `${entry.days_met} ${entry.days_met === 1 ? 'day met' : 'days met'}`;
@@ -366,7 +376,7 @@
                             listItem.appendChild(nameDiv);
                             listItem.appendChild(badge);
                             leaderboardList.appendChild(listItem);
-                        });                        
+                        });                   
                     }
 
                     leaderboardList.style.display = 'block';


### PR DESCRIPTION
###  What’s changed

This PR updates the leaderboard front-end rendering logic to ensure:

- 🥇🥈🥉 medals are assigned based on **appearance order** of unique rank values, not the raw `rank` number.
- Users with tied `days_met` scores now receive the **same medal**, preserving fair display.
- The leaderboard now only displays the **top 3 ranks** (including ties). Any user with `rank > 3` will no longer be shown.

###  Problem before

Previously, if rank 2 was skipped (e.g., due to multiple users tied for rank 1), the next user would still get 🥉 instead of 🥈. Also, users beyond rank 3 were being displayed, which conflicted with design intent.

###  Fix summary

- Introduced a `medalRankMap` that tracks the order of unique ranks and maps them to 🥇🥈🥉 accordingly.
- Ensured rendering only proceeds if the rank is within the top 3 distinct ranks.