### PR TITLE
Add Selenium End-to-End Tests for Key User Journeys

### DIFF
--- a/app/templates/addMeal.html
+++ b/app/templates/addMeal.html
@@ -113,7 +113,7 @@
             {# --- Buttons --- #}
             <div class="d-flex justify-content-between mt-4">
                 <a href="{{ url_for('main.dashboard') }}" class="btn btn-secondary">Cancel</a>
-                {{ form.submit(class="btn btn-primary") }}
+                {{ form.submit(class="btn btn-primary", id="addMealSubmit") }}
             </div>
         </form>
         <br><br>

--- a/app/templates/home_base.html
+++ b/app/templates/home_base.html
@@ -62,7 +62,6 @@
                         <i class="fa-solid fa-bullseye"></i> {{ current_user.target_calories }} kcal
                     </div>
                 </div>
-                {% endif %}
 
                 <!-- Edit Profile Modal -->
                 <div class="modal fade" id="editProfileModal" tabindex="-1" aria-labelledby="editProfileModalLabel" aria-hidden="true">
@@ -230,6 +229,30 @@
         </div>
     </div>
 
+    <!-- Flash Toasts -->
+    <div class="position-fixed top-0 end-0 p-3" style="z-index: 1100">
+        {% with messages = get_flashed_messages(with_categories=true) %}
+        {% for category, message in messages %}
+            <div class="toast align-items-center text-bg-{{ category }} border-0 shadow show" role="alert" aria-live="assertive" aria-atomic="true">
+            <div class="d-flex">
+                <div class="toast-body">
+                {{ message }}
+                </div>
+                <button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast" aria-label="Close"></button>
+            </div>
+            </div>
+        {% endfor %}
+        {% endwith %}
+    </div>
+    <script>
+        document.addEventListener('DOMContentLoaded', function () {
+            const toastElList = [].slice.call(document.querySelectorAll('.toast'));
+            toastElList.forEach(function (toastEl) {
+            const toast = new bootstrap.Toast(toastEl, { delay: 3000 });
+            toast.show();
+            });
+        });
+    </script>    
     <!-- Bootstrap JS Bundle with Popper -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/js/bootstrap.bundle.min.js"></script>
     <!-- jQuery -->
@@ -246,12 +269,7 @@
 
 
 
-    <script defer>
-        const messages = {{ get_flashed_messages() | tojson }};
-        if (messages.length > 0) {
-            flash(messages.join('\n'));
-        }
-    </script>
+
     <script>
         document.addEventListener('DOMContentLoaded', function() {
 

--- a/app/templates/home_base.html
+++ b/app/templates/home_base.html
@@ -43,26 +43,26 @@
             <!-- Sidebar -->
             <div class="sidebar">
                 <!-- Profile Section -->
+                {% if current_user.is_authenticated %}
                 <div class="profile-section">
                     <div class="avatar">
                         <img src="{{ current_user.avatar_url or url_for('static', filename='avatars/default_avatar.png') }}"
-                        alt="User Avatar"
-                        class="img-fluid rounded-circle"
-                        style="width: 100px; height: 80px; object-fit: cover;">
+                            alt="User Avatar"
+                            class="img-fluid rounded-circle"
+                            style="width: 100px; height: 80px; object-fit: cover;">
                     </div>
                     <div class="username">{{ current_user.first_name or 'User' }} {{ current_user.last_name or '' }}</div>
                     <div class="email text-muted small mb-2">{{ current_user.email }}</div>
-                
-                    {# --- Edit Profile button --- #}
                     <div class="button">
-                    <button type="button" class="btn btn-sm btn-outline-light me-2" data-bs-toggle="modal" data-bs-target="#editProfileModal">
-                        <i class="fa-solid fa-pencil me-1"></i> Edit Profile
-                    </button>
+                        <button type="button" class="btn btn-sm btn-outline-light me-2" data-bs-toggle="modal" data-bs-target="#editProfileModal">
+                            <i class="fa-solid fa-pencil me-1"></i> Edit Profile
+                        </button>
                     </div>
                     <div class="calorie-badge mt-2">
                         <i class="fa-solid fa-bullseye"></i> {{ current_user.target_calories }} kcal
                     </div>
                 </div>
+                {% endif %}
 
                 <!-- Edit Profile Modal -->
                 <div class="modal fade" id="editProfileModal" tabindex="-1" aria-labelledby="editProfileModalLabel" aria-hidden="true">
@@ -111,6 +111,8 @@
                     </div>
                     </div>
                 </div>
+                {% endif %}
+
 
                 <!-- Navigation Section -->
                 <div class="navigation-section">

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -158,6 +158,30 @@
     </div>
 </div>
 </div>
+<!-- Flash Toasts -->
+<div class="position-fixed top-0 end-0 p-3" style="z-index: 1100">
+    {% with messages = get_flashed_messages(with_categories=true) %}
+    {% for category, message in messages %}
+        <div class="toast align-items-center text-bg-{{ category }} border-0 shadow show" role="alert" aria-live="assertive" aria-atomic="true">
+        <div class="d-flex">
+            <div class="toast-body">
+            {{ message }}
+            </div>
+            <button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast" aria-label="Close"></button>
+        </div>
+        </div>
+    {% endfor %}
+    {% endwith %}
+</div>
+<script>
+    document.addEventListener('DOMContentLoaded', function () {
+        const toastElList = [].slice.call(document.querySelectorAll('.toast'));
+        toastElList.forEach(function (toastEl) {
+        const toast = new bootstrap.Toast(toastEl, { delay: 3000 });
+        toast.show();
+        });
+    });
+</script>
 {% endblock %}
 
 {% block extra_js %}

--- a/tests/selenium/test_user_journey_full.py
+++ b/tests/selenium/test_user_journey_full.py
@@ -11,15 +11,23 @@ DEFAULT_RECEIVER_PASSWORD = "DailyBite"
 def register_user(driver, suffix=""):
     driver.get(f"{BASE_URL}/auth/register")
     WebDriverWait(driver, 10).until(EC.presence_of_element_located((By.NAME, "firstName")))
+    time.sleep(1)
+
     email = f"user_{suffix}@example.com"
     password = "TestPass123"
 
     driver.find_element(By.NAME, "firstName").send_keys("User")
+    time.sleep(0.5)
     driver.find_element(By.NAME, "lastName").send_keys(suffix)
+    time.sleep(0.5)
     driver.find_element(By.NAME, "emailRegister").send_keys(email)
+    time.sleep(0.5)
     driver.find_element(By.NAME, "passwordRegister").send_keys(password)
+    time.sleep(0.5)
     driver.find_element(By.NAME, "passwordRegisterRepeat").send_keys(password)
+    time.sleep(0.5)
     driver.execute_script("arguments[0].click();", driver.find_element(By.ID, "SignUpLocation"))
+    time.sleep(1)
 
     WebDriverWait(driver, 10).until(EC.presence_of_element_located((By.CLASS_NAME, "dashboard-container")))
     time.sleep(2)
@@ -28,69 +36,94 @@ def register_user(driver, suffix=""):
 def login(driver, email, password):
     driver.get(f"{BASE_URL}/auth/login")
     WebDriverWait(driver, 10).until(EC.presence_of_element_located((By.NAME, "emailLogin")))
+    time.sleep(1)
+
     driver.find_element(By.NAME, "emailLogin").send_keys(email)
+    time.sleep(0.5)
     driver.find_element(By.NAME, "passwordLogin").send_keys(password)
+    time.sleep(0.5)
     driver.execute_script("arguments[0].click();", driver.find_element(By.CSS_SELECTOR, 'input[type="submit"]'))
+    time.sleep(1)
+
     WebDriverWait(driver, 10).until(EC.presence_of_element_located((By.CLASS_NAME, "dashboard-container")))
     time.sleep(2)
 
 def test_full_user_journey():
-    sender_driver = webdriver.Chrome()
+    driver = webdriver.Chrome()
     uid = str(uuid.uuid4())[:8]
-    sender_email, sender_pwd = register_user(sender_driver, f"sender{uid}")
+    sender_email, sender_pwd = register_user(driver, f"sender{uid}")
 
-    # 添加食物
-    sender_driver.get(f"{BASE_URL}/addMeal")
-    WebDriverWait(sender_driver, 10).until(EC.presence_of_element_located((By.ID, "foodInput")))
-    time.sleep(2)
-    sender_driver.find_element(By.ID, "foodInput").send_keys("chicken")
-    sender_driver.find_element(By.ID, "searchFoodLink").click()
+    # Add meal
+    driver.get(f"{BASE_URL}/addMeal")
+    WebDriverWait(driver, 10).until(EC.presence_of_element_located((By.ID, "foodInput")))
+    time.sleep(1)
+
+    driver.find_element(By.ID, "foodInput").send_keys("chicken")
+    time.sleep(1)
+    driver.find_element(By.ID, "searchFoodLink").click()
     time.sleep(2)
 
-    results = sender_driver.find_elements(By.CLASS_NAME, "searchResult")
+    results = driver.find_elements(By.CLASS_NAME, "searchResult")
     if results:
         results[0].click()
-        sender_driver.find_element(By.ID, "quantityInput").clear()
-        sender_driver.find_element(By.ID, "quantityInput").send_keys("150")
-        sender_driver.execute_script("arguments[0].click();", sender_driver.find_element(By.CSS_SELECTOR, 'form input[type="submit"]'))
-        WebDriverWait(sender_driver, 10).until(EC.presence_of_element_located((By.ID, "calorieTrendChart")))
+        time.sleep(1)
+
+        meal_type_select = driver.find_element(By.ID, "mealTypeInput")
+        for option in meal_type_select.find_elements(By.TAG_NAME, "option"):
+            if option.text.strip() == "Lunch":
+                option.click()
+                break
+        time.sleep(1)
+
+        driver.find_element(By.ID, "quantityInput").clear()
+        driver.find_element(By.ID, "quantityInput").send_keys("150")
+        time.sleep(1)
+
+        submit_btn = driver.find_element(By.ID, "addMealSubmit")
+        driver.execute_script("arguments[0].click();", submit_btn)
+        WebDriverWait(driver, 10).until(EC.presence_of_element_located((By.ID, "calorieTrendChart")))
         time.sleep(2)
 
-    # 切换图表按钮
-    btn_today = sender_driver.find_element(By.CSS_SELECTOR, 'button.time-range-btn[data-range="day"]')
-    sender_driver.execute_script("arguments[0].click();", btn_today)
+    # Change view mode today/last 7 days
+    btn_today = driver.find_element(By.CSS_SELECTOR, 'button.time-range-btn[data-range="day"]')
+    driver.execute_script("arguments[0].click();", btn_today)
     time.sleep(2)
 
-    # 分享模态框
-    sender_driver.execute_script("arguments[0].click();", sender_driver.find_element(By.ID, "openShareBtn"))
-    time.sleep(2)
-    search_input = WebDriverWait(sender_driver, 5).until(EC.element_to_be_clickable((By.ID, "friendSearchInput")))
+    # share
+    driver.execute_script("arguments[0].click();", driver.find_element(By.ID, "openShareBtn"))
+    time.sleep(1)
+
+    search_input = WebDriverWait(driver, 5).until(EC.element_to_be_clickable((By.ID, "friendSearchInput")))
     search_input.send_keys(DEFAULT_RECEIVER_EMAIL)
-    sender_driver.execute_script("arguments[0].click();", sender_driver.find_element(By.ID, "friendSearchBtn"))
-    time.sleep(2)
-    sender_driver.execute_script("arguments[0].click();", sender_driver.find_elements(By.NAME, "selected_friend_id")[0])
-    sender_driver.execute_script("arguments[0].click();", sender_driver.find_element(By.CSS_SELECTOR, "button[type='submit']"))
-    WebDriverWait(sender_driver, 5).until(EC.presence_of_element_located((By.CLASS_NAME, "toast-body")))
+    time.sleep(1)
+
+    driver.execute_script("arguments[0].click();", driver.find_element(By.ID, "friendSearchBtn"))
     time.sleep(2)
 
-    # ✅ 改为直接跳转到登录页（不依赖页面元素）
-    sender_driver.get(f"{BASE_URL}/logout")
+    driver.execute_script("arguments[0].click();", driver.find_elements(By.NAME, "selected_friend_id")[0])
+    time.sleep(1)
+    driver.execute_script("arguments[0].click();", driver.find_element(By.CSS_SELECTOR, "button[type='submit']"))
+    WebDriverWait(driver, 5).until(EC.presence_of_element_located((By.CLASS_NAME, "toast-body")))
     time.sleep(2)
-    sender_driver.get(f"{BASE_URL}/auth/login")
-    time.sleep(2)
-    sender_driver.quit()
 
-    # 登录默认用户查看分享
-    receiver_driver = webdriver.Chrome()
-    login(receiver_driver, DEFAULT_RECEIVER_EMAIL, DEFAULT_RECEIVER_PASSWORD)
-    receiver_driver.get(f"{BASE_URL}/sharing_list")
-    WebDriverWait(receiver_driver, 5).until(EC.presence_of_element_located((By.CLASS_NAME, "sharing-item-link"))).click()
-    chart = WebDriverWait(receiver_driver, 5).until(EC.presence_of_element_located((By.ID, "chartContainer")))
+    # logout and login as receiver
+    driver.get(f"{BASE_URL}/auth/logout")
+    time.sleep(1)
+
+    login(driver, DEFAULT_RECEIVER_EMAIL, DEFAULT_RECEIVER_PASSWORD)
+
+    # check shared meal
+    driver.get(f"{BASE_URL}/sharing_list")
+    time.sleep(1)
+    WebDriverWait(driver, 5).until(EC.presence_of_element_located((By.CLASS_NAME, "sharing-item-link"))).click()
+    time.sleep(1)
+
+    chart = WebDriverWait(driver, 5).until(EC.presence_of_element_located((By.ID, "chartContainer")))
     assert chart is not None
     time.sleep(2)
 
-    print("[✅] 全流程测试通过！")
-    receiver_driver.quit()
+    print("[✅] ALL Pass!")
+    driver.quit()
 
 if __name__ == "__main__":
     test_full_user_journey()

--- a/tests/selenium/test_user_journey_full.py
+++ b/tests/selenium/test_user_journey_full.py
@@ -5,125 +5,92 @@ from selenium.webdriver.support import expected_conditions as EC
 import time, uuid
 
 BASE_URL = "http://127.0.0.1:5000"
-DEFAULT_RECEIVER_EMAIL = "william@DailyBite.com"
-DEFAULT_RECEIVER_PASSWORD = "DailyBite"
-
-def register_user(driver, suffix=""):
-    driver.get(f"{BASE_URL}/auth/register")
-    WebDriverWait(driver, 10).until(EC.presence_of_element_located((By.NAME, "firstName")))
-    time.sleep(1)
-
-    email = f"user_{suffix}@example.com"
-    password = "TestPass123"
-
-    driver.find_element(By.NAME, "firstName").send_keys("User")
-    time.sleep(0.5)
-    driver.find_element(By.NAME, "lastName").send_keys(suffix)
-    time.sleep(0.5)
-    driver.find_element(By.NAME, "emailRegister").send_keys(email)
-    time.sleep(0.5)
-    driver.find_element(By.NAME, "passwordRegister").send_keys(password)
-    time.sleep(0.5)
-    driver.find_element(By.NAME, "passwordRegisterRepeat").send_keys(password)
-    time.sleep(0.5)
-    driver.execute_script("arguments[0].click();", driver.find_element(By.ID, "SignUpLocation"))
-    time.sleep(1)
-
-    WebDriverWait(driver, 10).until(EC.presence_of_element_located((By.CLASS_NAME, "dashboard-container")))
-    time.sleep(2)
-    return email, password
+DEFAULT_EMAIL = "william@dailybite.com"
+DEFAULT_PASSWORD = "DailyBite"
+RECEIVER_EMAIL = "haoran@dailybite.com"
+RECEIVER_PASSWORD = "DailyBite"
 
 def login(driver, email, password):
     driver.get(f"{BASE_URL}/auth/login")
     WebDriverWait(driver, 10).until(EC.presence_of_element_located((By.NAME, "emailLogin")))
     time.sleep(1)
-
     driver.find_element(By.NAME, "emailLogin").send_keys(email)
     time.sleep(0.5)
     driver.find_element(By.NAME, "passwordLogin").send_keys(password)
     time.sleep(0.5)
     driver.execute_script("arguments[0].click();", driver.find_element(By.CSS_SELECTOR, 'input[type="submit"]'))
-    time.sleep(1)
-
     WebDriverWait(driver, 10).until(EC.presence_of_element_located((By.CLASS_NAME, "dashboard-container")))
-    time.sleep(2)
+    time.sleep(1)
 
-def test_full_user_journey():
+def test_register_user():
     driver = webdriver.Chrome()
-    uid = str(uuid.uuid4())[:8]
-    sender_email, sender_pwd = register_user(driver, f"sender{uid}")
-
-    # Add meal
-    driver.get(f"{BASE_URL}/addMeal")
-    WebDriverWait(driver, 10).until(EC.presence_of_element_located((By.ID, "foodInput")))
+    driver.get(f"{BASE_URL}/auth/register")
+    WebDriverWait(driver, 10).until(EC.presence_of_element_located((By.NAME, "firstName")))
+    suffix = str(uuid.uuid4())[:8]
+    email = f"user_{suffix}@example.com"
+    pwd = "TestPass123"
+    driver.find_element(By.NAME, "firstName").send_keys("User")
+    driver.find_element(By.NAME, "lastName").send_keys(suffix)
+    driver.find_element(By.NAME, "emailRegister").send_keys(email)
+    driver.find_element(By.NAME, "passwordRegister").send_keys(pwd)
+    driver.find_element(By.NAME, "passwordRegisterRepeat").send_keys(pwd)
+    driver.execute_script("arguments[0].click();", driver.find_element(By.ID, "SignUpLocation"))
+    WebDriverWait(driver, 10).until(EC.presence_of_element_located((By.CLASS_NAME, "dashboard-container")))
+    print("[✅] Registration test passed")
     time.sleep(1)
-
-    driver.find_element(By.ID, "foodInput").send_keys("chicken")
-    time.sleep(1)
-    driver.find_element(By.ID, "searchFoodLink").click()
-    time.sleep(2)
-
-    results = driver.find_elements(By.CLASS_NAME, "searchResult")
-    if results:
-        results[0].click()
-        time.sleep(1)
-
-        meal_type_select = driver.find_element(By.ID, "mealTypeInput")
-        for option in meal_type_select.find_elements(By.TAG_NAME, "option"):
-            if option.text.strip() == "Lunch":
-                option.click()
-                break
-        time.sleep(1)
-
-        driver.find_element(By.ID, "quantityInput").clear()
-        driver.find_element(By.ID, "quantityInput").send_keys("150")
-        time.sleep(1)
-
-        submit_btn = driver.find_element(By.ID, "addMealSubmit")
-        driver.execute_script("arguments[0].click();", submit_btn)
-        WebDriverWait(driver, 10).until(EC.presence_of_element_located((By.ID, "calorieTrendChart")))
-        time.sleep(2)
-
-    # Change view mode today/last 7 days
-    btn_today = driver.find_element(By.CSS_SELECTOR, 'button.time-range-btn[data-range="day"]')
-    driver.execute_script("arguments[0].click();", btn_today)
-    time.sleep(2)
-
-    # share
-    driver.execute_script("arguments[0].click();", driver.find_element(By.ID, "openShareBtn"))
-    time.sleep(1)
-
-    search_input = WebDriverWait(driver, 5).until(EC.element_to_be_clickable((By.ID, "friendSearchInput")))
-    search_input.send_keys(DEFAULT_RECEIVER_EMAIL)
-    time.sleep(1)
-
-    driver.execute_script("arguments[0].click();", driver.find_element(By.ID, "friendSearchBtn"))
-    time.sleep(2)
-
-    driver.execute_script("arguments[0].click();", driver.find_elements(By.NAME, "selected_friend_id")[0])
-    time.sleep(1)
-    driver.execute_script("arguments[0].click();", driver.find_element(By.CSS_SELECTOR, "button[type='submit']"))
-    WebDriverWait(driver, 5).until(EC.presence_of_element_located((By.CLASS_NAME, "toast-body")))
-    time.sleep(2)
-
-    # logout and login as receiver
-    driver.get(f"{BASE_URL}/auth/logout")
-    time.sleep(1)
-
-    login(driver, DEFAULT_RECEIVER_EMAIL, DEFAULT_RECEIVER_PASSWORD)
-
-    # check shared meal
-    driver.get(f"{BASE_URL}/sharing_list")
-    time.sleep(1)
-    WebDriverWait(driver, 5).until(EC.presence_of_element_located((By.CLASS_NAME, "sharing-item-link"))).click()
-    time.sleep(1)
-
-    chart = WebDriverWait(driver, 5).until(EC.presence_of_element_located((By.ID, "chartContainer")))
-    assert chart is not None
-    time.sleep(2)
-
-    print("[✅] ALL Pass!")
     driver.quit()
 
-if __name__ == "__main__":
-    test_full_user_journey()
+def test_login():
+    driver = webdriver.Chrome()
+    login(driver, DEFAULT_EMAIL, DEFAULT_PASSWORD)
+    print("[✅] Login test passed")
+    time.sleep(1)
+    driver.quit()
+
+def test_add_meal():
+    driver = webdriver.Chrome()
+    login(driver, DEFAULT_EMAIL, DEFAULT_PASSWORD)
+    driver.get(f"{BASE_URL}/addMeal")
+    WebDriverWait(driver, 10).until(EC.presence_of_element_located((By.ID, "foodInput")))
+    driver.find_element(By.ID, "foodInput").send_keys("chicken")
+    driver.find_element(By.ID, "searchFoodLink").click()
+    time.sleep(2)
+    driver.find_elements(By.CLASS_NAME, "searchResult")[0].click()
+    driver.find_element(By.ID, "quantityInput").clear()
+    driver.find_element(By.ID, "quantityInput").send_keys("150")
+    driver.execute_script("arguments[0].click();", driver.find_element(By.ID, "addMealSubmit"))
+    WebDriverWait(driver, 10).until(EC.presence_of_element_located((By.ID, "calorieTrendChart")))
+    print("[✅] Add meal test passed")
+    time.sleep(1)
+    driver.quit()
+
+def test_switch_view():
+    driver = webdriver.Chrome()
+    login(driver, DEFAULT_EMAIL, DEFAULT_PASSWORD)
+    button = WebDriverWait(driver, 10).until(EC.element_to_be_clickable((By.CSS_SELECTOR, 'button.time-range-btn[data-range="day"]')))
+    driver.execute_script("arguments[0].click();", button)
+    print("[✅] View switch test passed")
+    time.sleep(1)
+    driver.quit()
+
+def test_share_and_receive():
+    driver = webdriver.Chrome()
+    login(driver, DEFAULT_EMAIL, DEFAULT_PASSWORD)
+    driver.execute_script("arguments[0].click();", driver.find_element(By.ID, "openShareBtn"))
+    time.sleep(1)
+    driver.find_element(By.ID, "friendSearchInput").send_keys(RECEIVER_EMAIL)
+    driver.execute_script("arguments[0].click();", driver.find_element(By.ID, "friendSearchBtn"))
+    time.sleep(1)
+    driver.execute_script("arguments[0].click();", driver.find_elements(By.NAME, "selected_friend_id")[0])
+    driver.execute_script("arguments[0].click();", driver.find_element(By.CSS_SELECTOR, "button[type='submit']"))
+    WebDriverWait(driver, 5).until(EC.presence_of_element_located((By.CLASS_NAME, "toast-body")))
+    time.sleep(1)
+
+    driver.get(f"{BASE_URL}/auth/logout")
+    login(driver, RECEIVER_EMAIL, RECEIVER_PASSWORD)
+    driver.get(f"{BASE_URL}/sharing_list")
+    WebDriverWait(driver, 5).until(EC.presence_of_element_located((By.CLASS_NAME, "sharing-item-link"))).click()
+    WebDriverWait(driver, 5).until(EC.presence_of_element_located((By.ID, "chartContainer")))
+    print("[✅] Share & receive test passed")
+    time.sleep(1)
+    driver.quit()

--- a/tests/selenium/test_user_journey_full.py
+++ b/tests/selenium/test_user_journey_full.py
@@ -1,0 +1,96 @@
+from selenium import webdriver
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
+import time, uuid
+
+BASE_URL = "http://127.0.0.1:5000"
+DEFAULT_RECEIVER_EMAIL = "william@DailyBite.com"
+DEFAULT_RECEIVER_PASSWORD = "DailyBite"
+
+def register_user(driver, suffix=""):
+    driver.get(f"{BASE_URL}/auth/register")
+    WebDriverWait(driver, 10).until(EC.presence_of_element_located((By.NAME, "firstName")))
+    email = f"user_{suffix}@example.com"
+    password = "TestPass123"
+
+    driver.find_element(By.NAME, "firstName").send_keys("User")
+    driver.find_element(By.NAME, "lastName").send_keys(suffix)
+    driver.find_element(By.NAME, "emailRegister").send_keys(email)
+    driver.find_element(By.NAME, "passwordRegister").send_keys(password)
+    driver.find_element(By.NAME, "passwordRegisterRepeat").send_keys(password)
+    driver.execute_script("arguments[0].click();", driver.find_element(By.ID, "SignUpLocation"))
+
+    WebDriverWait(driver, 10).until(EC.presence_of_element_located((By.CLASS_NAME, "dashboard-container")))
+    time.sleep(2)
+    return email, password
+
+def login(driver, email, password):
+    driver.get(f"{BASE_URL}/auth/login")
+    WebDriverWait(driver, 10).until(EC.presence_of_element_located((By.NAME, "emailLogin")))
+    driver.find_element(By.NAME, "emailLogin").send_keys(email)
+    driver.find_element(By.NAME, "passwordLogin").send_keys(password)
+    driver.execute_script("arguments[0].click();", driver.find_element(By.CSS_SELECTOR, 'input[type="submit"]'))
+    WebDriverWait(driver, 10).until(EC.presence_of_element_located((By.CLASS_NAME, "dashboard-container")))
+    time.sleep(2)
+
+def test_full_user_journey():
+    sender_driver = webdriver.Chrome()
+    uid = str(uuid.uuid4())[:8]
+    sender_email, sender_pwd = register_user(sender_driver, f"sender{uid}")
+
+    # 添加食物
+    sender_driver.get(f"{BASE_URL}/addMeal")
+    WebDriverWait(sender_driver, 10).until(EC.presence_of_element_located((By.ID, "foodInput")))
+    time.sleep(2)
+    sender_driver.find_element(By.ID, "foodInput").send_keys("chicken")
+    sender_driver.find_element(By.ID, "searchFoodLink").click()
+    time.sleep(2)
+
+    results = sender_driver.find_elements(By.CLASS_NAME, "searchResult")
+    if results:
+        results[0].click()
+        sender_driver.find_element(By.ID, "quantityInput").clear()
+        sender_driver.find_element(By.ID, "quantityInput").send_keys("150")
+        sender_driver.execute_script("arguments[0].click();", sender_driver.find_element(By.CSS_SELECTOR, 'form input[type="submit"]'))
+        WebDriverWait(sender_driver, 10).until(EC.presence_of_element_located((By.ID, "calorieTrendChart")))
+        time.sleep(2)
+
+    # 切换图表按钮
+    btn_today = sender_driver.find_element(By.CSS_SELECTOR, 'button.time-range-btn[data-range="day"]')
+    sender_driver.execute_script("arguments[0].click();", btn_today)
+    time.sleep(2)
+
+    # 分享模态框
+    sender_driver.execute_script("arguments[0].click();", sender_driver.find_element(By.ID, "openShareBtn"))
+    time.sleep(2)
+    search_input = WebDriverWait(sender_driver, 5).until(EC.element_to_be_clickable((By.ID, "friendSearchInput")))
+    search_input.send_keys(DEFAULT_RECEIVER_EMAIL)
+    sender_driver.execute_script("arguments[0].click();", sender_driver.find_element(By.ID, "friendSearchBtn"))
+    time.sleep(2)
+    sender_driver.execute_script("arguments[0].click();", sender_driver.find_elements(By.NAME, "selected_friend_id")[0])
+    sender_driver.execute_script("arguments[0].click();", sender_driver.find_element(By.CSS_SELECTOR, "button[type='submit']"))
+    WebDriverWait(sender_driver, 5).until(EC.presence_of_element_located((By.CLASS_NAME, "toast-body")))
+    time.sleep(2)
+
+    # ✅ 改为直接跳转到登录页（不依赖页面元素）
+    sender_driver.get(f"{BASE_URL}/logout")
+    time.sleep(2)
+    sender_driver.get(f"{BASE_URL}/auth/login")
+    time.sleep(2)
+    sender_driver.quit()
+
+    # 登录默认用户查看分享
+    receiver_driver = webdriver.Chrome()
+    login(receiver_driver, DEFAULT_RECEIVER_EMAIL, DEFAULT_RECEIVER_PASSWORD)
+    receiver_driver.get(f"{BASE_URL}/sharing_list")
+    WebDriverWait(receiver_driver, 5).until(EC.presence_of_element_located((By.CLASS_NAME, "sharing-item-link"))).click()
+    chart = WebDriverWait(receiver_driver, 5).until(EC.presence_of_element_located((By.ID, "chartContainer")))
+    assert chart is not None
+    time.sleep(2)
+
+    print("[✅] 全流程测试通过！")
+    receiver_driver.quit()
+
+if __name__ == "__main__":
+    test_full_user_journey()


### PR DESCRIPTION
### Summary
This pull request introduces a comprehensive suite of 5 Selenium tests that cover the core user flows of the DailyBite application.

### Tests Included
1. **`test_register_user`** – Tests new user registration flow.
2. **`test_login`** – Tests login with default user `william@dailybite.com`.
3. **`test_add_meal`** – Tests adding a meal after login (uses Open Food Facts search + quantity input).
4. **`test_switch_view`** – Tests toggling the calorie chart view to daily.
5. **`test_share_and_receive`** – Tests sharing the chart from William to Haoran, and verifying chart rendering upon receiving.

### Technical Notes
- Only one user is registered during testing (`test_register_user`).
- All other features are tested using two pre-defined accounts:
  - `william@dailybite.com` (sender)
  - `haoran@dailybite.com` (receiver)
  - Both accounts share the same password for simplicity (`DailyBite`).
- Added delays and waits to ensure UI elements load properly and improve test clarity.

### How to Run
From the `tests/selenium` directory, run:

```bash
pytest test_user_journey_full.py