### PR TITLE
Add email notification on successful share

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,3 +147,14 @@ pytest --driver Chrome tests/selenium
 # Generate an HTML coverage report
 pytest --cov=app --cov-report=html
 ```
+## 6. Additional information
+
+### Email Notification Feature
+
+This app uses Gmail SMTP to send share notification emails.
+
+To test this:
+1. Create a Gmail account.
+2. Enable 2-Step Verification.
+3. Generate an App Password: https://myaccount.google.com/apppasswords
+4. Replace the password in `.env` or `config.py`.


### PR DESCRIPTION
### Summary

- Added email notification after successful content sharing.
- When a user shares data with a friend, the recipient now receives an email alert.
- Used Gmail SMTP via `smtplib` for sending emails securely using an app password.

### Changes

- Modified `/share` route to trigger `send_email()` after saving `ShareRecord`.
- Created `send_email()` utility function for SMTP-based email delivery.
- Included basic error handling for email failures.
- Email content includes sender name, shared range, and link to view the shared content.

### Notes

- Requires a valid Gmail app password during testing.
- Email sending can be disabled or mocked via future `EMAIL_ENABLED` config flag.